### PR TITLE
adapt urls to font-files for asset-pipeline

### DIFF
--- a/lib/fontello_rails_converter/cli.rb
+++ b/lib/fontello_rails_converter/cli.rb
@@ -132,8 +132,10 @@ module FontelloRailsConverter
         zipfile.extract(demo_file, target_file) { true }
         puts green("Copied #{target_file}")
 
-        converted_html = File.read(target_file).gsub! /css\//, "/assets/"
-        File.open(target_file, 'w') { |f| f.write(converted_html) }
+        icon_guide_html = File.read(target_file)
+        icon_guide_html.gsub! /css\//, "/assets/"
+        icon_guide_html.gsub! "url('./font/", "url('./assets/"
+        File.open(target_file, 'w') { |f| f.write(icon_guide_html) }
         puts green("Converted demo.html for asset pipeline")
       end
 


### PR DESCRIPTION
refs #27

This contains a fix for the problem discussed in #27 

> In this fontello-issue fontello/fontello#382 some CSS was inlined into the original demo.html (see fontello/fontello@1d9ba71).
The URLs in the inlined @font-face are not converted for the asset-pipeline.

> I suspect https://github.com/railslove/fontello_rails_converter/blob/master/lib/fontello_rails_converter/cli.rb#L128 would need to bee amended?
