### PR TITLE
Default name for fontello name

### DIFF
--- a/lib/fontello_rails_converter/cli.rb
+++ b/lib/fontello_rails_converter/cli.rb
@@ -183,7 +183,7 @@ module FontelloRailsConverter
 
       def fontello_name
         @_fontello_name ||= if config_file_exists?
-          JSON.parse(File.read(@options[:config_file]))['name']
+          JSON.parse(File.read(@options[:config_file]))['name'].presence || 'fontello'
         end
       end
   end


### PR DESCRIPTION
Seems fontello allows to create fonts without name and in our project we have the case like this one. And the config is the following:

```json
{
  "name": "",
  "css_prefix_text": "icon-",
  "css_use_suffix": false,
  "hinting": true,
  "units_per_em": 1000,
...
}
```

So we have this exception:

```ruby
/usr/local/opt/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/fontello_rails_converter-0.4.0/lib/fontello_rails_converter/cli.rb:77:in `read': no implicit conversion of nil into String (TypeError)
```

It worked before without name, and it was `fontello` before. So I added the fallback.