### PR TITLE
Recommend not loading into memory in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Main features:
 
 #### Rails app setup
 
-Add the gem to your Gemfile `gem 'fontello_rails_converter'` and run `bundle install`
+Add the gem to your Gemfile `gem 'fontello_rails_converter', :group => :development` and run `bundle install`.
 
 #### Get your icon font
 


### PR DESCRIPTION
Per https://github.com/railslove/fontello_rails_converter/issues/15 we should be recommending that people *not* load this gem into memory in production, right? Every little bit of memory counts :)