### PR TITLE
Respect --config-file when downloading

### DIFF
--- a/lib/fontello_rails_converter/cli.rb
+++ b/lib/fontello_rails_converter/cli.rb
@@ -132,10 +132,9 @@ module FontelloRailsConverter
       end
 
       def copy_config_json(zipfile, config_file)
-        puts "config.json:"
-        target_file = File.join @options[:font_dir], config_file.to_s.split("/").last
-        zipfile.extract(config_file, target_file) { true }
-        puts green("Copied #{target_file}")
+        puts "config file:"
+        zipfile.extract(config_file, @options[:config_file]) { true }
+        puts green("Copied #{@options[:config_file]}")
       end
 
       def copy_stylesheets(zipfile, files)

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -62,4 +62,18 @@ describe FontelloRailsConverter::Cli do
       end
     end
   end
+
+  describe '#copy_config_json' do
+    let(:zipfile) { instance_double('FontelloZipfile') }
+    let(:config_file_path) { 'test/config.json' }
+
+    subject {
+      cli.send(:copy_config_json, zipfile, config_file_path)
+    }
+
+    specify do
+      expect(zipfile).to receive(:extract).with(config_file_path, 'spec/fixtures/fontello/config.json')
+      subject
+    end
+  end
 end


### PR DESCRIPTION
We have an option for specifying a config file, but that option is only used when opening a session. Whenever a new build is downloaded we throw the config.json in the same tired old location.