### PR TITLE
Assets prefix

### DIFF
--- a/bin/fontello
+++ b/bin/fontello
@@ -19,7 +19,9 @@ def set_options_based_on_rails_root(options)
     zip_file: "#{options[:rails_root_dir]}/tmp/fontello.zip",
     config_file: "#{options[:asset_dir]}/fonts/config.json",
     fontello_session_id_file: "#{options[:rails_root_dir]}/tmp/fontello_session_id",
-    options_file: "#{options[:rails_root_dir]}/config/fontello_rails_converter.yml"
+    options_file: "#{options[:rails_root_dir]}/config/fontello_rails_converter.yml",
+    assets_prefix_css: "/assets",
+    assets_prefix_fonts: "/assets"
   })
 end
 

--- a/lib/fontello_rails_converter/cli.rb
+++ b/lib/fontello_rails_converter/cli.rb
@@ -160,12 +160,12 @@ module FontelloRailsConverter
       def convert_icon_guide
         content = File.read(icon_guide_target_file)
         File.open(icon_guide_target_file, 'w') do |f|
-          f.write self.class.convert_icon_guide_html(content)
+          f.write convert_icon_guide_html(content)
         end
         puts green("Converted demo.html for asset pipeline: #{icon_guide_target_file}")
       end
 
-      def self.convert_icon_guide_html(content)
+      def convert_icon_guide_html(content)
         content.gsub! /css\//, "/assets/"
         content.gsub! "url('./font/", "url('/assets/"
       end

--- a/lib/fontello_rails_converter/cli.rb
+++ b/lib/fontello_rails_converter/cli.rb
@@ -166,8 +166,8 @@ module FontelloRailsConverter
       end
 
       def convert_icon_guide_html(content)
-        content.gsub! /css\//, "/assets/"
-        content.gsub! "url('./font/", "url('/assets/"
+        content.gsub! /css\//, "#{@options[:assets_prefix_css]}/"
+        content.gsub! "url('./font\/", "url('#{@options[:assets_prefix_fonts]}/"
       end
 
       def config_file_exists?

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -7,12 +7,12 @@ describe FontelloRailsConverter::Cli do
     })
   }
 
-  describe '.convert_icon_guide_html' do
+  describe '#convert_icon_guide_html' do
     let(:content) { File.read('spec/fixtures/fontello-demo.html') }
     let(:converted_content) { File.read('spec/fixtures/converted/fontello-demo.html') }
 
     specify do
-      expect(described_class.convert_icon_guide_html(content)).to eql converted_content
+      expect(cli.send(:convert_icon_guide_html, content)).to eql converted_content
     end
   end
 

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -1,15 +1,20 @@
 require 'spec_helper'
 
 describe FontelloRailsConverter::Cli do
-  let(:cli) { described_class.new({
-      config_file: 'spec/fixtures/fontello/config.json',
-      stylesheet_dir: 'vendor/assets/stylesheets'
-    })
+  let(:options) {{
+    config_file: 'spec/fixtures/fontello/config.json',
+    stylesheet_dir: 'vendor/assets/stylesheets'
+  }}
+  let(:cli) { described_class.new(options)
   }
 
   describe '#convert_icon_guide_html' do
     let(:content) { File.read('spec/fixtures/fontello-demo.html') }
     let(:converted_content) { File.read('spec/fixtures/converted/fontello-demo.html') }
+    let(:options){{
+      assets_prefix_css: '/assets',
+      assets_prefix_fonts: '/assets'
+    }}
 
     specify do
       expect(cli.send(:convert_icon_guide_html, content)).to eql converted_content


### PR DESCRIPTION
Although rails assets are _generally_ in `/assets` they can be configured to be served from elsewhere. This breaks the demo.

The reason for 2 separate options is that I use this gem in non-rails projects, where my fonts and css aren't necessarily in the same place.

Since we allow users to specify the css and font asset directories separately, it makes sense that they should also be able to separate them for the purpose of serving up the demo.

I would like to write a guide for using this project without rails in the future (specifically middleman). Or we could split the project into 2 gems, with fontello_rails_converter being a thin wrapper on a more generic fontello gem.
