### PR TITLE
woff2 support

### DIFF
--- a/lib/fontello_rails_converter/cli.rb
+++ b/lib/fontello_rails_converter/cli.rb
@@ -122,7 +122,7 @@ module FontelloRailsConverter
 
       def copy_font_files(zipfile, files)
         puts "font files:"
-        files.select{ |file| file.to_s.end_with?(".eot", ".woff", ".ttf", ".svg") }.each do |file|
+        files.select{ |file| file.to_s.end_with?(".eot", ".woff", ".woff2", ".ttf", ".svg") }.each do |file|
           filename = file.to_s.split("/").last
 
           target_file = File.join @options[:font_dir], filename

--- a/lib/fontello_rails_converter/railtie.rb
+++ b/lib/fontello_rails_converter/railtie.rb
@@ -3,7 +3,7 @@ module FontelloRailsConverter
 
     initializer "fontello_rails_converter.setup" do |app|
       app.config.assets.paths << Rails.root.join('vendor', 'assets', 'fonts')
-      app.config.assets.precompile << /\.(?:svg|eot|woff|ttf)$/
+      app.config.assets.precompile << /\.(?:svg|eot|woff|woff2|ttf)$/
     end
 
   end


### PR DESCRIPTION
Copies .woff2 files to match .scss file font-face rules. fixes #40 