### PR TITLE
Use HTTPS://

### DIFF
--- a/lib/fontello_rails_converter/fontello_api.rb
+++ b/lib/fontello_rails_converter/fontello_api.rb
@@ -3,7 +3,7 @@ require 'json'
 
 module FontelloRailsConverter
   class FontelloApi
-    FONTELLO_HOST = "http://fontello.com"
+    FONTELLO_HOST = "https://fontello.com"
 
     def initialize(options)
       @config_file = options[:config_file]


### PR DESCRIPTION
This gem is currently broken because Fontello now uses https:// by default.

Running `fontello open` for example will fail with this exception.

```
---- open ----
Traceback (most recent call last):
	15: from /Users/amirsharif/.rvm/gems/ruby-2.7.1/bin/ruby_executable_hooks:24:in `<main>'
	14: from /Users/amirsharif/.rvm/gems/ruby-2.7.1/bin/ruby_executable_hooks:24:in `eval'
	13: from /Users/amirsharif/.rvm/gems/ruby-2.7.1/bin/fontello:23:in `<main>'
	12: from /Users/amirsharif/.rvm/gems/ruby-2.7.1/bin/fontello:23:in `load'
	11: from /Users/amirsharif/.rvm/gems/ruby-2.7.1/gems/fontello_rails_converter-0.4.6/bin/fontello:138:in `<top (required)>'
	10: from /Users/amirsharif/.rvm/gems/ruby-2.7.1/gems/fontello_rails_converter-0.4.6/lib/fontello_rails_converter/cli.rb:17:in `open'
	 9: from /Users/amirsharif/.rvm/gems/ruby-2.7.1/gems/fontello_rails_converter-0.4.6/lib/fontello_rails_converter/fontello_api.rb:16:in `new_session_from_config'
	 8: from /Users/amirsharif/.rvm/gems/ruby-2.7.1/gems/rest-client-2.1.0/lib/restclient.rb:70:in `post'
	 7: from /Users/amirsharif/.rvm/gems/ruby-2.7.1/gems/rest-client-2.1.0/lib/restclient/request.rb:63:in `execute'
	 6: from /Users/amirsharif/.rvm/gems/ruby-2.7.1/gems/rest-client-2.1.0/lib/restclient/request.rb:163:in `execute'
	 5: from /Users/amirsharif/.rvm/gems/ruby-2.7.1/gems/rest-client-2.1.0/lib/restclient/request.rb:727:in `transmit'
	 4: from /Users/amirsharif/.rvm/rubies/ruby-2.7.1/lib/ruby/2.7.0/net/http.rb:933:in `start'
	 3: from /Users/amirsharif/.rvm/gems/ruby-2.7.1/gems/rest-client-2.1.0/lib/restclient/request.rb:743:in `block in transmit'
	 2: from /Users/amirsharif/.rvm/gems/ruby-2.7.1/gems/rest-client-2.1.0/lib/restclient/request.rb:836:in `process_result'
	 1: from /Users/amirsharif/.rvm/gems/ruby-2.7.1/gems/rest-client-2.1.0/lib/restclient/abstract_response.rb:123:in `return!'
/Users/amirsharif/.rvm/gems/ruby-2.7.1/gems/rest-client-2.1.0/lib/restclient/abstract_response.rb:249:in `exception_with_response': 301 Moved Permanently (RestClient::MovedPermanently)
```